### PR TITLE
Make Redis Hostname Configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ var app = express();
 // To connect to another port, say 8000, run the node app as
 // node index.js 8000
 var redisPort = process.argv[2] || 6379;
-var redisClient = redis.createClient(redisPort);
+// Hostname of Redis, defaults to localhost
+var redisHostname = process.argv[3] || 'localhost'
+
+var redisClient = redis.createClient(redisPort, redisHostname);
 
 // Scan 1000 keys at a time
 var SCAN_START = 0;


### PR DESCRIPTION
Instead of hardcoding the Redis Hostname to _localhost_, make it configurable with a default value of _localhost_ 